### PR TITLE
Support Advance Map 1.95 tileset and map import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project somewhat adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).  The MAJOR version number is bumped when there are **"Breaking Changes"** in the pret projects. For more on this, see [the manual page on breaking changes](https://huderlem.github.io/porymap/manual/breaking-changes.html).
 
 ## [Unreleased]
-Nothing, yet.
+### Fixed
+- Importing tileset metatiles from Advance Map 1.95 always used the primary tileset.
+- Map layouts exported from Advance Map 1.95 were sliced and placed incorrectly when imported.
+- Map layout imports no longer fail when the Advance Map `.map` file size differs from the expected value.
 
 ## [6.2.0] - 2025-08-08
 ### Added

--- a/docs/_sources/manual/tileset-editor.rst.txt
+++ b/docs/_sources/manual/tileset-editor.rst.txt
@@ -110,11 +110,11 @@ The tile image is an indexed png of 8x8 pixel tiles, which are used to form
 metatiles in the tileset editor.
 
 
-Import Metatiles from Advance Map 1.92...
------------------------------------------
+Import Metatiles from Advance Map 1.92 or 1.95...
+-----------------------------------------------
 
 Helpful for users converting projects from binary hacks. 
-Metatile data exported from Advance Map 1.92 in a ``.bvd``` file can be imported
+Metatile data exported from Advance Map 1.92 or 1.95 in a ``.bvd`` file can be imported
 into porymap's tileset editor.
 This saves a lot of time since metatiles will not have to be defined from scratch.
 

--- a/docs/_sources/reference/CHANGELOG.md.txt
+++ b/docs/_sources/reference/CHANGELOG.md.txt
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project somewhat adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).  The MAJOR version number is bumped when there are **"Breaking Changes"** in the pret projects. For more on this, see [the manual page on breaking changes](https://huderlem.github.io/porymap/manual/breaking-changes.html).
 
 ## [Unreleased]
-Nothing, yet.
+### Fixed
+- Importing tileset metatiles from Advance Map 1.95 always used the primary tileset.
+- Map layouts exported from Advance Map 1.95 were sliced and placed incorrectly when imported.
+- Map layout imports no longer fail when the Advance Map `.map` file size differs from the expected value.
 
 ## [6.2.0] - 2025-08-08
 ### Added

--- a/docs/genindex.html
+++ b/docs/genindex.html
@@ -134,7 +134,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="manual/tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -136,7 +136,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="manual/tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/breaking-changes.html
+++ b/docs/manual/breaking-changes.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/creating-new-maps.html
+++ b/docs/manual/creating-new-maps.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/editing-map-collisions.html
+++ b/docs/manual/editing-map-collisions.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/editing-map-connections.html
+++ b/docs/manual/editing-map-connections.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/editing-map-events.html
+++ b/docs/manual/editing-map-events.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/editing-map-header.html
+++ b/docs/manual/editing-map-header.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/editing-map-tiles.html
+++ b/docs/manual/editing-map-tiles.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/editing-wild-encounters.html
+++ b/docs/manual/editing-wild-encounters.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/introduction.html
+++ b/docs/manual/introduction.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/navigation.html
+++ b/docs/manual/navigation.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/project-files.html
+++ b/docs/manual/project-files.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/region-map-editor.html
+++ b/docs/manual/region-map-editor.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/scripting-capabilities.html
+++ b/docs/manual/scripting-capabilities.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/settings-and-options.html
+++ b/docs/manual/settings-and-options.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/shortcuts.html
+++ b/docs/manual/shortcuts.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/manual/tileset-editor.html
+++ b/docs/manual/tileset-editor.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="#other-tools">Other Tools</a></li>
 </ul>
@@ -513,9 +513,9 @@ The tile image is an indexed png of 8x8 pixel tiles, which are used to form
 metatiles in the tileset editor.</p>
 </section>
 <section id="import-metatiles-from-advance-map-1-92">
-<h3>Import Metatiles from Advance Map 1.92…<a class="headerlink" href="#import-metatiles-from-advance-map-1-92" title="Link to this heading"></a></h3>
+<h3>Import Metatiles from Advance Map 1.92 or 1.95…<a class="headerlink" href="#import-metatiles-from-advance-map-1-92" title="Link to this heading"></a></h3>
 <p>Helpful for users converting projects from binary hacks.
-Metatile data exported from Advance Map 1.92 in a <code class="docutils literal notranslate"><span class="pre">.bvd`</span></code> file can be imported
+Metatile data exported from Advance Map 1.92 or 1.95 in a <code class="docutils literal notranslate"><span class="pre">.bvd</span></code> file can be imported
 into porymap’s tileset editor.
 This saves a lot of time since metatiles will not have to be defined from scratch.</p>
 </section>

--- a/docs/reference/changelog.html
+++ b/docs/reference/changelog.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="../manual/tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="../manual/tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="../manual/tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="../manual/tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="../manual/tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="../manual/tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>
@@ -433,7 +433,14 @@
 and this project somewhat adheres to <a class="reference external" href="https://semver.org/spec/v2.0.0.html">Semantic Versioning</a>.  The MAJOR version number is bumped when there are <strong>“Breaking Changes”</strong> in the pret projects. For more on this, see <a class="reference external" href="https://huderlem.github.io/porymap/manual/breaking-changes.html">the manual page on breaking changes</a>.</p>
 <section id="unreleased">
 <h2><a class="reference external" href="https://github.com/huderlem/porymap/compare/6.2.0...HEAD">Unreleased</a><a class="headerlink" href="#unreleased" title="Link to this heading"></a></h2>
-<p>Nothing, yet.</p>
+<section id="fixed">
+<h3>Fixed<a class="headerlink" href="#fixed" title="Link to this heading"></a></h3>
+<ul class="simple">
+<li><p>Importing tileset metatiles from Advance Map 1.95 always used the primary tileset.</p></li>
+<li><p>Map layouts exported from Advance Map 1.95 were sliced and placed incorrectly when imported.</p></li>
+<li><p>Map layout imports no longer fail when the Advance Map <code class="docutils literal notranslate"><span class="pre">.map</span></code> file size differs from the expected value.</p></li>
+</ul>
+</section>
 </section>
 <section id="id1">
 <h2><a class="reference external" href="https://github.com/huderlem/porymap/compare/6.1.0...6.2.0">6.2.0</a> - 2025-08-08<a class="headerlink" href="#id1" title="Link to this heading"></a></h2>

--- a/docs/reference/related-projects.html
+++ b/docs/reference/related-projects.html
@@ -134,7 +134,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="../manual/tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="../manual/tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="../manual/tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="../manual/tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="../manual/tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="../manual/tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docs/search.html
+++ b/docs/search.html
@@ -137,7 +137,7 @@
 </li>
 <li class="toctree-l2"><a class="reference internal" href="manual/tileset-editor.html#tools-menu">Tools Menu</a><ul>
 <li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#import-tiles-image">Import Tiles Image…</a></li>
-<li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92…</a></li>
+<li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#import-metatiles-from-advance-map-1-92">Import Metatiles from Advance Map 1.92 or 1.95…</a></li>
 <li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#change-number-of-metatiles">Change Number of Metatiles</a></li>
 <li class="toctree-l3"><a class="reference internal" href="manual/tileset-editor.html#other-tools">Other Tools</a></li>
 </ul>

--- a/docsrc/manual/tileset-editor.rst
+++ b/docsrc/manual/tileset-editor.rst
@@ -110,11 +110,11 @@ The tile image is an indexed png of 8x8 pixel tiles, which are used to form
 metatiles in the tileset editor.
 
 
-Import Metatiles from Advance Map 1.92...
------------------------------------------
+Import Metatiles from Advance Map 1.92 or 1.95...
+-----------------------------------------------
 
 Helpful for users converting projects from binary hacks. 
-Metatile data exported from Advance Map 1.92 in a ``.bvd``` file can be imported
+Metatile data exported from Advance Map 1.92 or 1.95 in a ``.bvd`` file can be imported
 into porymap's tileset editor.
 This saves a lot of time since metatiles will not have to be defined from scratch.
 

--- a/src/core/advancemapparser.cpp
+++ b/src/core/advancemapparser.cpp
@@ -45,42 +45,74 @@ Layout *AdvanceMapParser::parseLayout(const QString &filepath, bool *error, cons
                                  (static_cast<unsigned char>(in.at(15)) << 24);
 
     int numMetatiles = mapWidth * mapHeight;
-    int expectedFileSize = 20 + (numBorderTiles * 2) + (numMetatiles * 2);
-    if (in.length() != expectedFileSize) {
-        if (numBorderTiles == 0) {
-            int expectedWithoutBorder = 20 + (numMetatiles * 2);
-            if (in.length() >= expectedWithoutBorder + 4) {
-                int borderWidthLE = static_cast<unsigned char>(in.at(in.length() - 4)) |
-                                    (static_cast<unsigned char>(in.at(in.length() - 3)) << 8);
-                int borderHeightLE = static_cast<unsigned char>(in.at(in.length() - 2)) |
-                                     (static_cast<unsigned char>(in.at(in.length() - 1)) << 8);
-                numBorderTiles = borderWidthLE * borderHeightLE;
-                mapDataOffset = 20; // map data follows header
-                expectedFileSize = expectedWithoutBorder + (numBorderTiles * 2) + 4;
-                if (in.length() == expectedFileSize) {
-                    borderWidth = borderWidthLE;
-                    borderHeight = borderHeightLE;
+    int baseMapSize = numMetatiles * 2;
+    int baseBorderSize = numBorderTiles * 2;
+
+    // Ensure the file has at least enough data for the header and one map.
+    int mapDataEnd = mapDataOffset + baseMapSize;
+    if (in.length() < mapDataEnd) {
+        *error = true;
+        logError(QString(".map file has too little data. Expected at least %1 bytes, but it has %2 bytes.")
+                    .arg(mapDataEnd).arg(in.length()));
+        return nullptr;
+    }
+
+    bool doubleMap = false;
+
+    // Handle the RSE format where border data is stored at the end of the file.
+    int rseBorderOffset = -1;
+    if (numBorderTiles == 0) {
+        // Map data follows the header, and border data (if present) is at the end
+        // with width/height stored in the last 4 bytes.
+        if (in.length() >= mapDataEnd + 4) {
+            int borderWidthLE = static_cast<unsigned char>(in.at(in.length() - 4)) |
+                                (static_cast<unsigned char>(in.at(in.length() - 3)) << 8);
+            int borderHeightLE = static_cast<unsigned char>(in.at(in.length() - 2)) |
+                                 (static_cast<unsigned char>(in.at(in.length() - 1)) << 8);
+            int rseNumBorderTiles = borderWidthLE * borderHeightLE;
+            int rseBorderSize = rseNumBorderTiles * 2;
+            int borderOffset = in.length() - (rseBorderSize + 4);
+            if (borderOffset >= mapDataOffset + baseMapSize) {
+                // At least one full map and border data exist.
+                if (borderOffset >= mapDataOffset + baseMapSize * 2) {
+                    doubleMap = true; // Ignore the second layout; use the first.
                 }
+                borderWidth = borderWidthLE;
+                borderHeight = borderHeightLE;
+                numBorderTiles = rseNumBorderTiles;
+                baseBorderSize = rseBorderSize;
+                rseBorderOffset = borderOffset;
             }
         }
-        if (in.length() != expectedFileSize) {
-            *error = true;
-            logError(QString(".map file is an unexpected size. Expected %1 bytes, but it has %2 bytes.").arg(expectedFileSize).arg(in.length()));
-            return nullptr;
-        }    }
+    } else {
+        // FRLG format where border data comes right after the header.
+        if (in.length() >= mapDataOffset + baseMapSize * 2) {
+            doubleMap = true; // There is a second layout, ignore it.
+        }
+    }
 
     Blockdata blockdata;
-     int mapDataEnd = mapDataOffset + (numMetatiles * 2);
-    for (int i = mapDataOffset; (i + 1) < mapDataEnd; i += 2) {
+    for (int i = mapDataOffset; (i + 1) < mapDataEnd && (i + 1) < in.length(); i += 2) {
         uint16_t word = static_cast<uint16_t>((in[i] & 0xff) + ((in[i + 1] & 0xff) << 8));
         blockdata.append(word);
     }
 
     Blockdata border;
     if (numBorderTiles != 0) {
-        int borderOffset = (mapDataOffset == 20) ? mapDataEnd : 20;
-        int borderEnd = borderOffset + (numBorderTiles * 2);
-        for (int i = borderOffset; (i + 1) < borderEnd; i += 2) {
+        int borderOffset;
+        if (mapDataOffset == 20) {
+            // Border is at the end of the file after the map data (RSE).
+            if (rseBorderOffset >= 0) {
+                borderOffset = rseBorderOffset;
+            } else {
+                borderOffset = mapDataOffset + baseMapSize * (doubleMap ? 2 : 1);
+            }
+        } else {
+            // Border data is directly after the header (FRLG).
+            borderOffset = 20;
+        }
+        int borderEnd = borderOffset + baseBorderSize;
+        for (int i = borderOffset; (i + 1) < borderEnd && (i + 1) < in.length(); i += 2) {
             uint16_t word = static_cast<uint16_t>((in[i] & 0xff) + ((in[i + 1] & 0xff) << 8));
             border.append(word);
         }
@@ -174,11 +206,30 @@ QList<Metatile*> AdvanceMapParser::parseMetatiles(const QString &filepath, bool 
         return { };
     }
 
-    int expectedFileSize = 4 + (metatileSize * numMetatiles) + (attrSize * numMetatiles) + 4;
-    if (in.length() != expectedFileSize) {
+    int baseMetatileSize = metatileSize * numMetatiles;
+    int baseAttrSize = attrSize * numMetatiles;
+    int expectedSingleSize = baseMetatileSize + baseAttrSize + 8;
+    int expectedDoubleSize = (baseMetatileSize * 2) + (baseAttrSize * 2) + 8;
+    bool doubleTileset = false;
+    if (in.length() == expectedDoubleSize) {
+        doubleTileset = true;
+    } else if (in.length() != expectedSingleSize) {
         *error = true;
-        logError(QString(".bvd file is an unexpected size. Expected %1 bytes, but it has %2 bytes.").arg(expectedFileSize).arg(in.length()));
+        logError(QString(".bvd file is an unexpected size. Expected %1 or %2 bytes, but it has %3 bytes.").arg(expectedSingleSize).arg(expectedDoubleSize).arg(in.length()));
         return { };
+    }
+
+    int tilesOffset = 4;
+    int attrsOffset;
+    if (doubleTileset) {
+        if (primaryTileset) {
+            attrsOffset = 4 + (baseMetatileSize * 2);
+        } else {
+            tilesOffset += baseMetatileSize;
+            attrsOffset = 4 + (baseMetatileSize * 2) + baseAttrSize;
+        }
+    } else {
+        attrsOffset = 4 + baseMetatileSize;
     }
 
     QList<Metatile*> metatiles;
@@ -186,7 +237,7 @@ QList<Metatile*> AdvanceMapParser::parseMetatiles(const QString &filepath, bool 
         Metatile *metatile = new Metatile();
         QList<Tile> tiles;
         for (int j = 0; j < 8; j++) {
-            int metatileOffset = 4 + i * metatileSize + j * 2;
+            int metatileOffset = tilesOffset + i * metatileSize + j * 2;
             Tile tile(static_cast<uint16_t>(
                         static_cast<unsigned char>(in.at(metatileOffset)) |
                        (static_cast<unsigned char>(in.at(metatileOffset + 1)) << 8)));
@@ -201,7 +252,7 @@ QList<Metatile*> AdvanceMapParser::parseMetatiles(const QString &filepath, bool 
                 tiles.append(tile);
         }
 
-        int attrOffset = 4 + (numMetatiles * metatileSize) + (i * attrSize);
+        int attrOffset = attrsOffset + (i * attrSize);
         uint32_t attributes = 0;
         for (int j = 0; j < attrSize; j++)
             attributes |= static_cast<unsigned char>(in.at(attrOffset + j)) << (8 * j);


### PR DESCRIPTION
## Summary
- handle Advance Map 1.95 `.map` files containing two layout sections
- fix tileset import to respect secondary data in Advance Map `.bvd` files
- accept Advance Map `.map` files of any size by reading border info from the end

## Testing
- `QT_SELECT=qt5 qmake porymap.pro`
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_68a9110da72c8323a6acbbe3fb2639be